### PR TITLE
Enable IndieWeb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,5 @@ disqusShortname = "XXX"
 
 You can also inject arbitrary HTML into `<head>` simply by overriding the `extra-in-head.html`
 partial, which is meant for that purpose.
+
+The theme is also enabled with [IndieWeb](https://indieweb.org) support which can be validated via different tools at website [IndieWebify.me](https://indiewebify.me/).

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -25,6 +25,7 @@ googleAnalytics = "XXX"
     gplus = "https://google.com/+XXX"
     twitter = "https://twitter.com/XXX"
     stackoverflow = "https://stackoverflow.com/users/XXX/YYY"
+    webmentionEndpoint = "https://example.com/webmention"
     email = "XXX@example.com"
     opengraph = true
     shareTwitter = true

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -9,6 +9,8 @@ googleAnalytics = "XXX"
 [Author]
     name = "My Name"
     profile = "https://google.com/+XXX"
+    email = "XXX@example.com"
+    nick = "my-name"
 
 [Taxonomies]
     tag = "tags"

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -11,9 +11,17 @@
                         <i class="fa fa-angle-up"></i>
                     </a>
                 </div>
-
-                <p class="footer-copyright">
-                    <span>&copy; {{ .Site.LastChange.Format "2006" }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
+                
+                <p class="footer-copyright h-card vcard">
+		        	&copy; {{ .Site.LastChange.Format "2006" }} <a style="text-decoration: none" href={{ .Site.BaseURL }} 
+    	         	   class="p-name u-url url author metatag" rel="me">
+        	        	{{ .Site.Author.name }}
+	            	</a> /
+    	            <a class="p-nickname u-email email metatag" rel="me" 
+	    	            href="mailto:{{ .Site.Author.email }}">
+    	    	        {{ .Site.Author.nick }}
+        	   		</a> 
+        	   		/ Powered by <a href="https://gohugo.io/">Hugo</a></span>
                 </p>
                 <p class="footer-copyright">
                     <span><a href="https://github.com/roryg/ghostwriter">Ghostwriter theme</a> By <a href="http://jollygoodthemes.com">JollyGoodThemes</a></span>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -37,37 +37,37 @@
                         {{ end }}
                         <a class="button-square" href="{{ .Site.BaseURL }}index.xml"><i class="fa fa-rss"></i></a>
                         {{ with .Site.Params.twitter }}
-                            <a class="button-square button-social hint--top" data-hint="Twitter" title="Twitter" href="{{ . }}">
+                            <a class="button-square button-social hint--top" data-hint="Twitter" title="Twitter" href="{{ . }}" rel="me">
                                 <i class="fa fa-twitter"></i>
                             </a>
                         {{ end }}
                         {{ with .Site.Params.gitlab }}
-                            <a class="button-square button-social hint--top" data-hint="Gitlab" title="Gitlab" href="{{ . }}">
+                            <a class="button-square button-social hint--top" data-hint="Gitlab" title="Gitlab" href="{{ . }}" rel="me">
                                 <i class="fa fa-gitlab"></i>
                             </a>
                         {{ end }}
                         {{ with .Site.Params.github }}
-                            <a class="button-square button-social hint--top" data-hint="Github" title="Github" href="{{ . }}">
+                            <a class="button-square button-social hint--top" data-hint="Github" title="Github" href="{{ . }}" rel="me">
                                 <i class="fa fa-github-alt"></i>
                             </a>
                         {{ end }}
                         {{ with .Site.Params.stackoverflow }}
-                            <a class="button-square button-social hint--top" data-hint="Stack Overflow" title="Stack Overflow" href="{{ . }}">
+                            <a class="button-square button-social hint--top" data-hint="Stack Overflow" title="Stack Overflow" href="{{ . }}" rel="me">
                                 <i class="fa fa-stack-overflow"></i>
                             </a>
                         {{ end }}
                         {{ with .Site.Params.linkedin }}
-                            <a class="button-square button-social hint--top" data-hint="LinkedIn" title="LinkedIn" href="{{ . }}">
+                            <a class="button-square button-social hint--top" data-hint="LinkedIn" title="LinkedIn" href="{{ . }}" rel="me">
                                 <i class="fa fa-linkedin"></i>
                             </a>
                         {{ end }}
                         {{ with .Site.Params.gplus }}
-                            <a class="button-square button-social hint--top" data-hint="Google+" title="Google+" href="{{ . }}">
+                            <a class="button-square button-social hint--top" data-hint="Google+" title="Google+" href="{{ . }}" rel="me">
                                 <i class="fa fa-google-plus"></i>
                             </a>
                         {{ end }}
                         {{ with .Site.Params.email }}
-                            <a class="button-square button-social hint--top" data-hint="Email" title="Email" href="mailto:{{ . }}">
+                            <a class="button-square button-social hint--top" data-hint="Email" title="Email" href="mailto:{{ . }}" rel="me">
                                 <i class="fa fa-envelope"></i>
                             </a>
                         {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,6 +11,7 @@
         <meta name="robots" content="index,follow">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         {{ if .Site.Params.opengraph }}{{ partial "opengraph.html" . }}{{ end }}
+        {{ with .Site.Params.webmentionEndpoint }}<link rel="webmention" href="{{ . }}" /> {{ end }}
         <link rel="stylesheet" href="{{ .Site.BaseURL }}dist/styles.css">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&subset=latin,cyrillic-ext,latin-ext,cyrillic">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">

--- a/layouts/partials/post-content.html
+++ b/layouts/partials/post-content.html
@@ -1,4 +1,4 @@
-<div class="post-content clearfix" itemprop="articleBody">
+<div class="post-content clearfix e-content" itemprop="articleBody">
     {{ with .Params.Image }}
         <img class="post-featured-image" src="{{ . }}">
     {{ end }}

--- a/layouts/partials/post-header.html
+++ b/layouts/partials/post-header.html
@@ -1,14 +1,16 @@
 <header class="post-header">
-    <h1 class="post-title" itemprop="name headline">{{ .Title }}</h1>
+    <h1 class="post-title p-name" itemprop="name headline">{{ .Title }}</h1>
     {{ if .Description }}
         <p class="post-description" itemprop="description">{{ .Description }}</p>
     {{ end }}
     <p class="post-date">
-        <span>Published <time datetime="{{ .Date.Format "2006-01-02" }}" itemprop="datePublished">{{ dateFormat (default "Mon, Jan 2, 2006" .Site.Params.dateFormat) .Date }}</time></span>
+        <span>Published <a class="u-url" href="{{ .Permalink }}"><time class="dt-published" datetime="{{ .Date.Format "2006-01-02" }}" itemprop="datePublished">{{ dateFormat (default "Mon, Jan 2, 2006" .Site.Params.dateFormat) .Date }}</time></a></span>
         <span>by</span>
         <span itemscope="" itemprop="author" itemtype="https://schema.org/Person">
             <span itemprop="name">
-                <a href="{{ .Params.profile | default .Site.Author.profile | default "#" }}" itemprop="url" rel="author">{{ .Params.author | default .Site.Author.name }}</a>
+                <a href="{{ .Params.profile | default .Site.Author.profile | default "#" }}" itemprop="url" rel="author">
+                	<span class="p-author h-card">{{ .Params.author | default .Site.Author.name }}</span>
+                </a>
             </span>
         </span>
     </p>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,7 +1,7 @@
 {{ partial "header.html" . }}
 
 <div class="container">
-    <article class="post-container" itemscope="" itemtype="http://schema.org/BlogPosting">
+    <article class="post-container h-entry" itemscope="" itemtype="http://schema.org/BlogPosting">
         {{ partial "post-header.html" . }}
 
         {{ partial "post-content.html" . }}


### PR DESCRIPTION
IndieWeb is a trending project, focused mainly on allowing website owners to own and control their content, and also stay connected with engagement on them across services. All it needs is availability of some key classes on elements. This does not need any action on user's part, at the same time enabling below.

- Set up web sign-in via rel-me
- Add info about owner via h-card
- Add microformats to content via h-entry
- Allow configuring webmention endpoint 